### PR TITLE
Changed isMaster to isPr and baseSha condition

### DIFF
--- a/tools/scripts/calculate-commands.js
+++ b/tools/scripts/calculate-commands.js
@@ -1,6 +1,6 @@
 const execSync = require('child_process').execSync;
-const isMaster = process.argv[2] === 'False';
-const baseSha = isMaster ? 'origin/master~1' : 'origin/master';
+const isPr = process.argv[2] === 'True';
+const baseSha = isPr ? 'origin/master~1' : 'origin/master';
 
 console.log(
   JSON.stringify({

--- a/tools/scripts/calculate-commands.js
+++ b/tools/scripts/calculate-commands.js
@@ -1,6 +1,6 @@
 const execSync = require('child_process').execSync;
 const isPr = process.argv[2] === 'True';
-const baseSha = isPr ? 'origin/master~1' : 'origin/master';
+const baseSha = isPr ? 'origin/master' : 'origin/master~1';
 
 console.log(
   JSON.stringify({


### PR DESCRIPTION
Changed isMaster to isPr to better reflect the input variable from the azure-pipelines.yml file.
Fixed baseSha condition.