### PR TITLE
fix for lint 3 job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
         succeeded(),
         not(contains(
           dependencies.initial_setup.outputs['setCommands.COMMANDS'],
-          '"lint2":[]'
+          '"lint3":[]'
         ))
       )
     pool:


### PR DESCRIPTION
Just a small fix. The Lint 3 job is checking if the lint2 array is empty, instead of checking lint3.